### PR TITLE
Remove redundant dependencies from buildSrc

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -5,15 +5,3 @@ plugins {
 repositories {
     mavenCentral()
 }
-
-dependencies {
-    compileOnly("org.jetbrains:annotations:24.0.1")
-    compileOnly("org.jspecify:jspecify:0.2.0")
-    // TODO: Update to 0.3.0 when more tools add support
-
-    testImplementation(platform("org.junit:junit-bom:5.9.3"))
-    testImplementation("org.junit.jupiter:junit-jupiter-api")
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
-    testImplementation("org.junit.jupiter:junit-jupiter-params")
-    testImplementation("org.mockito:mockito-core:5.4.0")
-}


### PR DESCRIPTION
Not sure why I thought they were needed... Only plugins are required to be on the class path so the scripts can be compiled...