### PR TITLE
Remove pointless documentation overrides

### DIFF
--- a/vision-api/src/main/java/me/sparky983/vision/Chest.java
+++ b/vision-api/src/main/java/me/sparky983/vision/Chest.java
@@ -68,14 +68,11 @@ public non-sealed interface Chest extends Gui {
     interface Builder extends Gui.Builder {
 
         /**
-         * Sets the title of the {@link Chest}.
+         * {@inheritDoc}
          *
-         * @param title {@inheritDoc}
-         * @return {@inheritDoc}
          * @throws NullPointerException {@inheritDoc}
          * @since 1.0
-         * @vision.apiNote After the {@link Chest} is built, the title cannot be changed, so it
-         * must be specified before the {@link Chest} is built
+         * @vision.apiNote {@inheritDoc}
          */
         @Override
         Builder title(Component title);
@@ -93,11 +90,8 @@ public non-sealed interface Chest extends Gui {
         Builder rows(int rows);
 
         /**
-         * Sets the {@link Button} at the specified {@link Slot} of the {@link Chest}.
+         * {@inheritDoc}
          *
-         * @param slot {@inheritDoc}
-         * @param button {@inheritDoc}
-         * @return {@inheritDoc}
          * @throws NullPointerException {@inheritDoc}
          * @since 1.0
          */
@@ -105,34 +99,24 @@ public non-sealed interface Chest extends Gui {
         Builder button(Slot slot, Button button);
 
         /**
-         * Sets all the empty slots to the specified {@link Button} in the {@link Chest}.
+         * {@inheritDoc}
          * <p>
          * If the amount of rows change via subsequent calls to {@link #rows(int)}, they will be
          * prefilled with the specified {@link Button}.
          *
-         * @param button {@inheritDoc}
-         * @return {@inheritDoc}
          * @throws NullPointerException {@inheritDoc}
          * @since 1.0
+         * @vision.experimental {@inheritDoc}
          */
         @Override
         Builder fill(Button button);
 
         /**
-         * Sets the specified borders of the {@link Chest} to the specified {@link Button}.
-         * <p>
-         * Changes to the border set after this method is called will not affect the {@link Chest}.
-         * <p>
-         * When the {@link Chest} is built, the {@link Button Buttons} will be placed in the empty
-         * slots covered by the borders. If a border has been specified multiple times, the last
-         * specified {@link Button} will be used. The same is the case for corners.
+         * {@inheritDoc}
          * <p>
          * The borders are set during {@link #build()}, so subsequent calls to {@link #rows(int)}
          * will move the {@link Border#BOTTOM bottom border}.
          *
-         * @param button {@inheritDoc}
-         * @param borders {@inheritDoc}
-         * @return {@inheritDoc}
          * @throws NullPointerException {@inheritDoc}
          * @throws IllegalArgumentException {@inheritDoc}
          * @since 1.0
@@ -142,21 +126,11 @@ public non-sealed interface Chest extends Gui {
         Builder border(Button button, Set<Border> borders);
 
         /**
-         * Sets the specified borders of the {@link Chest} to the specified {@link Button}.
-         * <p>
-         * Changes to the border array after this method is called will not affect the
-         * {@link Chest}.
-         * <p>
-         * When the {@link Chest} is built, the {@link Button Buttons} will be placed in the empty
-         * slots covered by the borders. If a border has been specified multiple times, the last
-         * specified {@link Button} will be used. The same is the case for corners.
+         * {@inheritDoc}
          * <p>
          * The borders are set during {@link #build()}, so subsequent calls to {@link #rows(int)}
          * will move the {@link Border#BOTTOM bottom border}.
          *
-         * @param button {@inheritDoc}
-         * @param borders {@inheritDoc}
-         * @return {@inheritDoc}
          * @throws NullPointerException {@inheritDoc}
          * @throws IllegalArgumentException {@inheritDoc}
          * @since 1.0
@@ -166,17 +140,11 @@ public non-sealed interface Chest extends Gui {
         Builder border(Button button, Border... borders);
 
         /**
-         * Sets all the borders of the {@link Chest} to the specified {@link Button}.
-         * <p>
-         * When the {@link Chest} is built, the {@link Button Buttons} will be placed in all empty
-         * border slots. If a border has been specified multiple times, the last specified
-         * {@link Button} will be used. The same is the case for corners.
+         * {@inheritDoc}
          * <p>
          * The borders are set during {@link #build()}, so subsequent calls to {@link #rows(int)}
          * will move the {@link Border#BOTTOM bottom border}.
          *
-         * @param button {@inheritDoc}
-         * @return {@inheritDoc}
          * @throws NullPointerException {@inheritDoc}
          * @since 1.0
          * @vision.experimental {@inheritDoc}
@@ -185,13 +153,8 @@ public non-sealed interface Chest extends Gui {
         Builder border(Button button);
 
         /**
-         * Builds the {@link Chest}.
-         * <p>
-         * If both a {@link #fill(Button) fill} and a {@link #border(Button, Set) border} has been
-         * specified, the {@link #border(Button, Set) border} will overlay the {@link #fill(Button)}
-         * in the returned {@link Chest}.
+         * {@inheritDoc}
          *
-         * @return the built {@link Chest}
          * @throws IllegalStateException {@inheritDoc}
          * @since 1.0
          */

--- a/vision-api/src/main/java/me/sparky983/vision/Dropper.java
+++ b/vision-api/src/main/java/me/sparky983/vision/Dropper.java
@@ -56,24 +56,18 @@ public non-sealed interface Dropper extends Gui {
     interface Builder extends Gui.Builder {
 
         /**
-         * Sets the title of the {@link Dropper}.
+         * {@inheritDoc}
          *
-         * @param title {@inheritDoc}
-         * @return {@inheritDoc}
          * @throws NullPointerException {@inheritDoc}
          * @since 1.0
-         * @vision.apiNote After the {@link Gui} is built, the title cannot be changed, so it
-         * must be specified before the {@link Gui} is built
+         * @vision.apiNote {@inheritDoc}
          */
         @Override
         Builder title(Component title);
 
         /**
-         * Sets the {@link Button} at the specified {@link Slot} of the {@link Dropper}.
+         * {@inheritDoc}
          *
-         * @param slot {@inheritDoc}
-         * @param button {@inheritDoc}
-         * @return {@inheritDoc}
          * @throws NullPointerException {@inheritDoc}
          * @since 1.0
          */
@@ -81,29 +75,18 @@ public non-sealed interface Dropper extends Gui {
         Builder button(Slot slot, Button button);
 
         /**
-         * Sets all the empty slots to the specified {@link Button} in the {@link Dropper}.
+         * {@inheritDoc}
          *
-         * @param button {@inheritDoc}
-         * @return {@inheritDoc}
          * @throws NullPointerException {@inheritDoc}
          * @since 1.0
+         * @vision.experimental {@inheritDoc}
          */
         @Override
         Builder fill(Button button);
 
         /**
-         * Sets the specified borders of the {@link Dropper} to the specified {@link Button}.
-         * <p>
-         * Changes to the border set after this method is called will not affect the
-         * {@link Dropper}.
-         * <p>
-         * When the {@link Dropper} is built, the {@link Button Buttons} will be placed in the empty
-         * slots covered by the borders. If a border has been specified multiple times, the last
-         * specified {@link Button} will be used. The same is the case for corners.
+         * {@inheritDoc}
          *
-         * @param button {@inheritDoc}
-         * @param borders {@inheritDoc}
-         * @return {@inheritDoc}
          * @throws NullPointerException {@inheritDoc}
          * @throws IllegalArgumentException {@inheritDoc}
          * @since 1.0
@@ -113,18 +96,8 @@ public non-sealed interface Dropper extends Gui {
         Builder border(Button button, Set<Border> borders);
 
         /**
-         * Sets the specified borders of the {@link Dropper} to the specified {@link Button}.
-         * <p>
-         * Changes to the border array after this method is called will not affect the
-         * {@link Dropper}.
-         * <p>
-         * When the {@link Dropper} is built, the {@link Button Buttons} will be placed in the empty
-         * slots covered by the borders. If a border has been specified multiple times, the last
-         * specified {@link Button} will be used. The same is the case for corners.
+         * {@inheritDoc}
          *
-         * @param button {@inheritDoc}
-         * @param borders {@inheritDoc}
-         * @return {@inheritDoc}
          * @throws NullPointerException {@inheritDoc}
          * @throws IllegalArgumentException {@inheritDoc}
          * @since 1.0
@@ -134,14 +107,8 @@ public non-sealed interface Dropper extends Gui {
         Builder border(Button button, Border... borders);
 
         /**
-         * Sets all the borders of the {@link Dropper} to the specified {@link Button}.
-         * <p>
-         * When the {@link Dropper} is built, the {@link Button Buttons} will be placed in all empty
-         * border slots. If a border has been specified multiple times, the last specified
-         * {@link Button} will be used. The same is the case for corners.
+         * {@inheritDoc}
          *
-         * @param button {@inheritDoc}
-         * @return {@inheritDoc}
          * @throws NullPointerException {@inheritDoc}
          * @since 1.0
          * @vision.experimental {@inheritDoc}
@@ -150,13 +117,8 @@ public non-sealed interface Dropper extends Gui {
         Builder border(Button button);
 
         /**
-         * Builds the {@link Dropper}.
-         * <p>
-         * If both a {@link #fill(Button) fill} and a {@link #border(Button, Set) border} has been
-         * specified, the {@link #border(Button, Set) border} will overlay the {@link #fill(Button)}
-         * in the returned {@link Dropper}.
+         * {@inheritDoc}
          *
-         * @return the built {@link Dropper}
          * @throws IllegalStateException {@inheritDoc}
          * @since 1.0
          */

--- a/vision-api/src/main/java/me/sparky983/vision/Hopper.java
+++ b/vision-api/src/main/java/me/sparky983/vision/Hopper.java
@@ -56,24 +56,18 @@ public non-sealed interface Hopper extends Gui {
     interface Builder extends Gui.Builder {
 
         /**
-         * Sets the title of the {@link Hopper}.
+         * {@inheritDoc}
          *
-         * @param title {@inheritDoc}
-         * @return {@inheritDoc}
          * @throws NullPointerException {@inheritDoc}
          * @since 1.0
-         * @vision.apiNote After the {@link Gui} is built, the title cannot be changed, so it
-         * must be specified before the {@link Gui} is built
+         * @vision.apiNote {@inheritDoc}
          */
         @Override
         Builder title(Component title);
 
         /**
-         * Sets the {@link Button} at the specified {@link Slot} of the {@link Hopper}.
+         * {@inheritDoc}
          *
-         * @param slot {@inheritDoc}
-         * @param button {@inheritDoc}
-         * @return {@inheritDoc}
          * @throws NullPointerException {@inheritDoc}
          * @since 1.0
          */
@@ -81,28 +75,18 @@ public non-sealed interface Hopper extends Gui {
         Builder button(Slot slot, Button button);
 
         /**
-         * Sets all the empty slots to the specified {@link Button} in the {@link Hopper}.
+         * {@inheritDoc}
          *
-         * @param button {@inheritDoc}
-         * @return {@inheritDoc}
          * @throws NullPointerException {@inheritDoc}
          * @since 1.0
+         * @vision.experimental {@inheritDoc}
          */
         @Override
         Builder fill(Button button);
 
         /**
-         * Sets the specified borders of the {@link Hopper} to the specified {@link Button}.
-         * <p>
-         * Changes to the border set after this method is called will not affect the {@link Hopper}.
-         * <p>
-         * When the {@link Hopper} is built, the {@link Button Buttons} will be placed in the empty
-         * slots covered by the borders. If a border has been specified multiple times, the last
-         * specified {@link Button} will be used. The same is the case for corners.
+         * {@inheritDoc}
          *
-         * @param button {@inheritDoc}
-         * @param borders {@inheritDoc}
-         * @return {@inheritDoc}
          * @throws NullPointerException {@inheritDoc}
          * @throws IllegalArgumentException {@inheritDoc}
          * @since 1.0
@@ -112,18 +96,8 @@ public non-sealed interface Hopper extends Gui {
         Builder border(Button button, Set<Border> borders);
 
         /**
-         * Sets the specified borders of the {@link Hopper} to the specified {@link Button}.
-         * <p>
-         * Changes to the border array after this method is called will not affect the
-         * {@link Hopper}.
-         * <p>
-         * When the {@link Hopper} is built, the {@link Button Buttons} will be placed in the empty
-         * slots covered by the borders. If a border has been specified multiple times, the last
-         * specified {@link Button} will be used. The same is the case for corners.
+         * {@inheritDoc}
          *
-         * @param button {@inheritDoc}
-         * @param borders {@inheritDoc}
-         * @return {@inheritDoc}
          * @throws NullPointerException {@inheritDoc}
          * @throws IllegalArgumentException {@inheritDoc}
          * @since 1.0
@@ -133,14 +107,8 @@ public non-sealed interface Hopper extends Gui {
         Builder border(Button button, Border... borders);
 
         /**
-         * Sets all the borders of the {@link Hopper} to the specified {@link Button}.
-         * <p>
-         * When the {@link Hopper} is built, the {@link Button Buttons} will be placed in all empty
-         * border slots. If a border has been specified multiple times, the last specified
-         * {@link Button} will be used. The same is the case for corners.
+         * {@inheritDoc}
          *
-         * @param button {@inheritDoc}
-         * @return {@inheritDoc}
          * @throws NullPointerException {@inheritDoc}
          * @since 1.0
          * @vision.experimental {@inheritDoc}
@@ -149,13 +117,8 @@ public non-sealed interface Hopper extends Gui {
         Builder border(Button button);
 
         /**
-         * Builds the {@link Hopper}.
-         * <p>
-         * If both a {@link #fill(Button) fill} and a {@link #border(Button, Set) border} has been
-         * specified, the {@link #border(Button, Set) border} will overlay the {@link #fill(Button)}
-         * in the returned {@link Hopper}.
+         * {@inheritDoc}
          *
-         * @return the built {@link Hopper}
          * @throws IllegalStateException {@inheritDoc}
          * @since 1.0
          */


### PR DESCRIPTION
Removes the documentation overrides that only change `@link` tags to be slightly more specific.

`{@inheritDoc}`s are present in the summary sections to remove the "Copied from [parent]" text in the generated Javadoc. They are also required in `@throws` and `@vision.` tags since they're not implicitly inherited.